### PR TITLE
Changed temperature to 0 to revolve GPT parsing issue on Results Page…

### DIFF
--- a/src/pages/HTML/BasicPage.tsx
+++ b/src/pages/HTML/BasicPage.tsx
@@ -105,7 +105,7 @@ const BasicPage = () => {
 				"content": getResponses(), //calls the function that gets the user's responses to the quiz
 				}
 			],
-			temperature: 0.8,
+			temperature: 0,
 			max_tokens: 512, //should be 512
 			top_p: 1,
 			});

--- a/src/pages/HTML/DetailedPage.tsx
+++ b/src/pages/HTML/DetailedPage.tsx
@@ -216,7 +216,7 @@ const DetailedPage = () => {
 				"content": getResponses(), //calls the function that puts the user's responses into the correct format
 				}
 			],
-			temperature: 0.8,
+			temperature: 0,
 			max_tokens: 512,//should be 512
 			top_p: 1,
 			});


### PR DESCRIPTION
Results page would have an issue where all the text would be in the main header and not properly split up.
This happened by chance according to our tests so we changed the OpenAI's temperature to 0.